### PR TITLE
Bundler based dependency loading

### DIFF
--- a/lib/sovren.rb
+++ b/lib/sovren.rb
@@ -1,6 +1,5 @@
-require "pry"
+Bundler.require(:default,ENV["SOVREN_ENV"]) if defined?(Bundler)
 require "sovren/version"
-require "savon"
 
 module Sovren
   class << self


### PR DESCRIPTION
Looks for env variable SOVREN_ENV to decide whether to load
groups for bundler, similar to how RAILS_ENV is used
