### PR TITLE
Update nokogiri to 1.6.x

### DIFF
--- a/sovren.gemspec
+++ b/sovren.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "savon", "~> 2.2.0"
   spec.add_dependency "httpclient", "~> 2.3.3"
-  spec.add_dependency "nokogiri", "~> 1.5.9"
+  spec.add_dependency "nokogiri", "~> 1.6.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
I'm using a version of fog that depended on 1.6 nokogiri so there was a conflict.  All the specs pass with nokogiri 1.6 so this looks safe.
